### PR TITLE
Add support for vscode

### DIFF
--- a/src/Bannerlord.Module.CSharp/.template.config/template.json
+++ b/src/Bannerlord.Module.CSharp/.template.config/template.json
@@ -193,6 +193,13 @@
       }
     },
     
+    "code": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "Generate the project with this argument set to true if you intend to use VSCode as IDE",
+      "defaultValue": "false"
+    },
+
     "langVersion": {
       "type": "parameter",
       "datatype": "text",
@@ -268,6 +275,41 @@
       "value": "(RequireBLSEFeatures == \"assembly-resolver\")"
     },
 
+    "gameBinariesFolder": {
+      "type": "generated",
+      "generator": "switch",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "gameWindowsStore == null",
+            "value": "Win64_Shipping_Client"
+          },
+          {
+            "condition": "(gameWindowsStore == false)",
+            "value": "Win64_Shipping_Client"
+          },
+          {
+            "condition": "(gameWindowsStore == true)",
+            "value": "Gaming.Desktop.x64_Shipping"
+          }
+        ]
+      },
+      "replaces": "BINARY_FOLDER"
+    },
+
+    "displayName":
+    {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "moduleName",
+        "fallbackVariableName": "name"
+      },
+      "replaces": "MODULE_NAME"
+    },
+
     "HostIdentifier": {
       "type": "bind",
       "binding": "HostIdentifier"
@@ -279,6 +321,24 @@
     }
   },
   "defaultName": "Bannerlord.Module1",
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(code == false)",
+          "exclude": [
+            ".vscode/**"
+          ]
+        },
+        {
+          "condition": "(code == true)",
+          "exclude": [
+            "Properties/**"
+          ]
+        }
+      ] 
+    }
+  ],
   "primaryOutputs": [
     {
       "path": "BLNamespace.csproj"

--- a/src/Bannerlord.Module.CSharp/.template.config/template.json
+++ b/src/Bannerlord.Module.CSharp/.template.config/template.json
@@ -283,11 +283,7 @@
         "datatype": "string",
         "cases": [
           {
-            "condition": "gameWindowsStore == null",
-            "value": "Win64_Shipping_Client"
-          },
-          {
-            "condition": "(gameWindowsStore == false)",
+            "condition": "(gameWindows == true)",
             "value": "Win64_Shipping_Client"
           },
           {

--- a/src/Bannerlord.Module.CSharp/.vscode/launch.json
+++ b/src/Bannerlord.Module.CSharp/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/src/Bannerlord.Module.CSharp/.vscode/launch.json
+++ b/src/Bannerlord.Module.CSharp/.vscode/launch.json
@@ -1,0 +1,37 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Start Debugging Module",
+            "type": "clr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${env:BANNERLORD_GAME_DIR}/bin/${config:gameBinaryFolder}/Bannerlord.exe",
+            "args": [
+                "/singleplayer",
+                "_MODULES_*Native*SandBoxCore*CustomBattle*Sandbox*StoryMode*${config:moduleName}*_MODULES_"
+            ],
+            "cwd": "${env:BANNERLORD_GAME_DIR}/bin/${config:gameBinaryFolder}",
+            "stopAtEntry": false,
+            "console": "internalConsole",
+            "internalConsoleOptions": "openOnSessionStart",
+            "justMyCode": false,
+            "logging": {
+                "moduleLoad": false
+            },
+        },
+        {
+            "name": "Attach",
+            "type": "clr",
+            "request": "attach",
+            "processName": "Bannerlord.exe",
+            "justMyCode": false,
+            "logging": {
+                "moduleLoad": false
+            },
+        }
+    ]
+}

--- a/src/Bannerlord.Module.CSharp/.vscode/settings.json
+++ b/src/Bannerlord.Module.CSharp/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "moduleName": "MODULE_NAME",
+    "gameBinaryFolder": "BINARY_FOLDER"
+}

--- a/src/Bannerlord.Module.CSharp/.vscode/tasks.json
+++ b/src/Bannerlord.Module.CSharp/.vscode/tasks.json
@@ -1,4 +1,3 @@
-// build task for C# bannerlord mod
 {
     "version": "2.0.0",
     "tasks": [

--- a/src/Bannerlord.Module.CSharp/.vscode/tasks.json
+++ b/src/Bannerlord.Module.CSharp/.vscode/tasks.json
@@ -1,0 +1,17 @@
+// build task for C# bannerlord mod
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile",
+        }
+    ]
+}

--- a/src/Bannerlord.Module.Sdk.CSharp/.template.config/template.json
+++ b/src/Bannerlord.Module.Sdk.CSharp/.template.config/template.json
@@ -266,11 +266,7 @@
         "datatype": "string",
         "cases": [
           {
-            "condition": "gameWindowsStore == null",
-            "value": "Win64_Shipping_Client"
-          },
-          {
-            "condition": "(gameWindowsStore == false)",
+            "condition": "(gameWindows == true)",
             "value": "Win64_Shipping_Client"
           },
           {

--- a/src/Bannerlord.Module.Sdk.CSharp/.template.config/template.json
+++ b/src/Bannerlord.Module.Sdk.CSharp/.template.config/template.json
@@ -179,6 +179,13 @@
       ],
       "defaultValue": "do-not-require-anything"
     },
+
+    "code": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "Generate the project with this argument if you intend to use VSCode as IDE",
+      "defaultValue": "false"
+    },
    
     "langVersion": {
       "type": "parameter",
@@ -251,6 +258,41 @@
       "value": "(RequireBLSEFeatures == \"assembly-resolver\")"
     },
 
+    "gameBinariesFolder": {
+      "type": "generated",
+      "generator": "switch",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "gameWindowsStore == null",
+            "value": "Win64_Shipping_Client"
+          },
+          {
+            "condition": "(gameWindowsStore == false)",
+            "value": "Win64_Shipping_Client"
+          },
+          {
+            "condition": "(gameWindowsStore == true)",
+            "value": "Gaming.Desktop.x64_Shipping"
+          }
+        ]
+      },
+      "replaces": "BINARY_FOLDER"
+    },
+
+    "displayName":
+    {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "moduleName",
+        "fallbackVariableName": "name"
+      },
+      "replaces": "MODULE_NAME"
+    },
+
     "HostIdentifier": {
       "type": "bind",
       "binding": "HostIdentifier"
@@ -262,6 +304,24 @@
     }
   },
   "defaultName": "Bannerlord.Module1",
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(code == false)",
+          "exclude": [
+            ".vscode/**"
+          ]
+        },
+        {
+          "condition": "(code == true)",
+          "exclude": [
+            "Properties/**"
+          ]
+        }
+      ] 
+    }
+  ],
   "primaryOutputs": [
     {
       "path": "BLNamespace.csproj"

--- a/src/Bannerlord.Module.Sdk.CSharp/.vscode/launch.json
+++ b/src/Bannerlord.Module.Sdk.CSharp/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/src/Bannerlord.Module.Sdk.CSharp/.vscode/launch.json
+++ b/src/Bannerlord.Module.Sdk.CSharp/.vscode/launch.json
@@ -1,0 +1,37 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Start Debugging Module",
+            "type": "clr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${env:BANNERLORD_GAME_DIR}/bin/${config:gameBinaryFolder}/Bannerlord.exe",
+            "args": [
+                "/singleplayer",
+                "_MODULES_*Native*SandBoxCore*CustomBattle*Sandbox*StoryMode*${config:moduleName}*_MODULES_"
+            ],
+            "cwd": "${env:BANNERLORD_GAME_DIR}/bin/${config:gameBinaryFolder}",
+            "stopAtEntry": false,
+            "console": "internalConsole",
+            "internalConsoleOptions": "openOnSessionStart",
+            "justMyCode": false,
+            "logging": {
+                "moduleLoad": false
+            },
+        },
+        {
+            "name": "Attach",
+            "type": "clr",
+            "request": "attach",
+            "processName": "Bannerlord.exe",
+            "justMyCode": false,
+            "logging": {
+                "moduleLoad": false
+            },
+        }
+    ]
+}

--- a/src/Bannerlord.Module.Sdk.CSharp/.vscode/settings.json
+++ b/src/Bannerlord.Module.Sdk.CSharp/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "moduleName": "MODULE_NAME",
+    "gameBinaryFolder": "BINARY_FOLDER",
+}

--- a/src/Bannerlord.Module.Sdk.CSharp/.vscode/tasks.json
+++ b/src/Bannerlord.Module.Sdk.CSharp/.vscode/tasks.json
@@ -1,4 +1,3 @@
-// build task for C# bannerlord mod
 {
     "version": "2.0.0",
     "tasks": [

--- a/src/Bannerlord.Module.Sdk.CSharp/.vscode/tasks.json
+++ b/src/Bannerlord.Module.Sdk.CSharp/.vscode/tasks.json
@@ -1,0 +1,17 @@
+// build task for C# bannerlord mod
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile",
+        }
+    ]
+}


### PR DESCRIPTION
## Premises

vscode cannot make use of the `Properties/launchSettings.json` file as it uses an unsupported `commandName`, only `project` is supported in vscode.

## What is this PR for

This PR aim to add launch & debug support of modules in vscode.

### Necessary files

To achieve this, 3 files are necessary:
- launch.json
- settings.json
- tasks.json

Only a single of those files, `launch.json`, requires the use of variables to make a newly created module, work properly.
those variables are stored in the `settings.json` files and is used by vscode to feed the appropriate values.

the 2 variables that are required are:
- The game binary folder (by default, Win64_Shipping_Client)
- The name of the module to debug

Unfortunately, the addition of 3 template symbols, including a single parameter are required.

### Template symbols

-c or --code will need to be used if the user intend to use vscode as their IDE.

Generated type symbols are used to replace the placeholders present within `settings.json` initially.

1. gameBinariesFolder:

If the `gameWindows` parameter is true, `gameBinariesFolder`'s value is the `Win64_Shipping_Client` folder, if not then,
If the `gameWindowsStore` parameter is true , `gameBinariesFolder`'s value is the `Gaming.Desktop.x64_Shipping` folder.

2. displayName:

a separate symbol to `moduleName` that control its presence, in the case that it is not, `sourceName` will be used (the `name` symbol represent that value)

### Folder exclusion

In the case that the user specify the use of vscode, the `Properties` folder will be excluded from the template.
The opposite, will be true if the user does not specify any values or false, `.vscode` will be excluded.

## What could be done on top of what is currently provided

If necessary, i can add the publish and watch tasks back to `tasks.json`